### PR TITLE
ci(release): automatizar GitHub Releases por tags v*

- actualiza package.yml para publicar release automatico con action-gh-release
- agrega job github-release con dependencias a todos los artefactos de build
- eleva permisos a contents: write para crear releases
- documenta comandos de versionado y push de tags en DEPLOYMENT.md

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   python-dist:
@@ -98,3 +98,32 @@ jobs:
         with:
           name: frontend-dist
           path: frontend/dist
+
+  github-release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs:
+      - python-dist
+      - pyinstaller
+      - source-archive
+      - docker-image
+      - frontend-build
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download workflow artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            release-assets/python-dist/*
+            release-assets/porthound-ubuntu-latest/*
+            release-assets/porthound-windows-latest/*
+            release-assets/porthound-macos-latest/*
+            release-assets/source-archive/*
+            release-assets/docker-image/*
+            release-assets/frontend-dist/**/*

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -50,6 +50,39 @@ docker push ${IMAGE}:production
 docker push ${IMAGE}:main
 ```
 
+## GitHub Release automatico (por tag)
+- Workflow: `.github/workflows/package.yml`
+- Trigger: push de tag con prefijo `v` (ejemplo: `v1.2.0`)
+- Resultado: compila artefactos y crea un GitHub Release con assets adjuntos.
+
+### Comandos para release estable (main)
+```bash
+git checkout main
+git pull origin main
+
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+### Comandos para pre-release (production/develop)
+```bash
+# ejemplo RC desde production
+git checkout production
+git pull origin production
+
+git tag v1.2.0-rc1
+git push origin v1.2.0-rc1
+```
+
+```bash
+# ejemplo beta desde develop
+git checkout develop
+git pull origin develop
+
+git tag v1.2.0-beta1
+git push origin v1.2.0-beta1
+```
+
 ## Systemd (Linux)
 Create a service file at `/etc/systemd/system/porthound.service`:
 


### PR DESCRIPTION
## Summary
- 

## Changes
- 

## Testing
- [x] Not run (explain why)
- [x] Manual testing
- [x] Automated tests

## Notes
- 
